### PR TITLE
support translations for spree static pages

### DIFF
--- a/app/controllers/spree/admin/pages_controller.rb
+++ b/app/controllers/spree/admin/pages_controller.rb
@@ -1,3 +1,16 @@
 class Spree::Admin::PagesController < Spree::Admin::ResourceController
-  
+  def translate
+    page = Spree::Page.find(params[:id])
+    page.update update_page_attribute
+    redirect_to spree.admin_pages_path
+  end
+
+  private
+  def update_page_attribute
+    params.require(:page).permit(permitted_params)
+  end
+
+  def permitted_params
+    [:translations_attributes => [:id, :title, :body, :slug, :layout, :layout, :foreign_link, :meta_keywords, :meta_title, :meta_description]]
+  end
 end

--- a/app/models/spree/page.rb
+++ b/app/models/spree/page.rb
@@ -17,6 +17,10 @@ class Spree::Page < ActiveRecord::Base
 
   scope :by_store, lambda { |store| joins(:stores).where("spree_pages_stores.store_id = ?", store) }
 
+  include Spree::RansackableAttributes
+  translates :title, :body, :slug, :layout, :foreign_link, :meta_keywords, :meta_title, :meta_description, fallbacks_for_empty_translations: true
+  include SpreeI18n::Translatable
+
   before_save :update_positions_and_slug
 
   def initialize(*args)

--- a/app/views/spree/admin/pages/index.html.erb
+++ b/app/views/spree/admin/pages/index.html.erb
@@ -29,6 +29,7 @@
     <td class="actions" data-hook="admin_pages_index_row_actions">
       <%= link_to_edit page, :no_text => true %>
       <%= link_to_delete page, :no_text => true %>
+      <%= link_to_with_icon 'translate', nil, admin_translations_path('page', page.id), title: Spree.t(:'i18n.translations'), class: 'btn btn-sm btn-primary' %>
     </td>
   </tr>
   <% end -%>

--- a/app/views/spree/admin/translations/page.html.erb
+++ b/app/views/spree/admin/translations/page.html.erb
@@ -1,0 +1,26 @@
+<% content_for :page_title do %>
+  <%= Spree.t(:editing_page) %> <span class="green">"<%= @page.title %>"</span>
+<% end %>
+
+<% content_for :page_actions do %>
+    <%= button_link_to Spree.t(:back_to_page_list), spree.admin_pages_path, class: 'btn-primary', icon: 'icon-arrow-left' %>
+<% end %>
+
+
+<%= render 'settings' %>
+
+<div class="row translations">
+    <div class="col-md-4">
+        <%= render 'fields' %>
+    </div>
+    <div class="col-md-8">
+        <%= form_for [:admin, @resource] do |f| %>
+          <%= render 'form_fields', f: f %>
+          <div class="form-buttons filter-actions actions" data-hook="buttons">
+              <%= button Spree.t(:update), 'update' %>
+              <span class="or"><%= Spree.t(:or) %></span>
+              <%= button_link_to Spree.t(:cancel), spree.edit_admin_page_path(@page), icon: 'remove' %>
+          </div>
+        <% end %>
+    </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Spree::Core::Engine.add_routes do
   namespace :admin do
-    resources :pages
+    resources :pages do
+      patch :translate, on: :member
+    end
   end
   constraints(Spree::StaticPage) do
     get '/(*path)', :to => 'static_content#show', :as => 'static'

--- a/db/migrate/20141024150705_add_translation_to_static_pages.rb
+++ b/db/migrate/20141024150705_add_translation_to_static_pages.rb
@@ -1,0 +1,11 @@
+class AddTranslationToStaticPages < ActiveRecord::Migration
+  def up
+    params = { title: :string, body: :text, slug: :string, layout: :string, foreign_link: :string, meta_keywords: :string, meta_title: :string, meta_description: :string }
+    I18n.default_locale = :ro
+    Spree::Page.create_translation_table!(params, { migrate_data: true })
+  end
+  
+  def down
+    Spree::Page.drop_translation_table! migrate_data: true
+  end
+end


### PR DESCRIPTION
Run the migration, add to Configurations -> Rich editor following fields: "page_translations_attributes_1_body page_translations_attributes_2_body" and you're good to go.