### PR TITLE
Intranet V1

### DIFF
--- a/app/controllers/spree/admin/intranet_controller.rb
+++ b/app/controllers/spree/admin/intranet_controller.rb
@@ -1,21 +1,10 @@
 module Spree
   module Admin
     class IntranetController < ResourceController
-      before_action :authorize_intranet_access
-
       def index
-        @pages = Spree::Page.where(show_on_intranet: true)
       end
 
       def show
-      end
-
-      private
-      def authorize_intranet_access
-        unless !spree_current_user&.admin?
-          flash[:notice] = "You are not authorized to access this page."
-          redirect_to spree.admin_pages_path
-        end
       end
 
       protected

--- a/app/controllers/spree/admin/intranet_controller.rb
+++ b/app/controllers/spree/admin/intranet_controller.rb
@@ -1,0 +1,27 @@
+module Spree
+  module Admin
+    class IntranetController < ResourceController
+      before_action :authorize_intranet_access
+
+      def index
+        @pages = Spree::Page.where(show_on_intranet: true)
+      end
+
+      def show
+      end
+
+      private
+      def authorize_intranet_access
+        unless !spree_current_user&.admin?
+          flash[:notice] = "You are not authorized to access this page."
+          redirect_to spree.admin_pages_path
+        end
+      end
+
+      protected
+        def model_class
+          Spree::Page
+        end
+    end
+  end
+end

--- a/app/controllers/spree/admin/pages_controller.rb
+++ b/app/controllers/spree/admin/pages_controller.rb
@@ -1,16 +1,24 @@
-class Spree::Admin::PagesController < Spree::Admin::ResourceController
-  def translate
-    page = Spree::Page.find(params[:id])
-    page.update update_page_attribute
-    redirect_to spree.admin_pages_path
-  end
+module Spree
+  module Admin
+    class PagesController < ResourceController
+      def translate
+        page = Spree::Page.find(params[:id])
+        page.update update_page_attribute
+        redirect_to spree.admin_pages_path
+      end
+
+      def index
+        @pages = Spree::Page.visible.where(show_on_intranet: false)
+      end
 
   private
   def update_page_attribute
     params.require(:page).permit(permitted_params)
   end
 
-  def permitted_params
-    [:translations_attributes => [:id, :title, :body, :slug, :layout, :layout, :foreign_link, :meta_keywords, :meta_title, :meta_description]]
+      def permitted_params
+        [:translations_attributes => [:id, :title, :body, :slug, :layout, :foreign_link, :meta_keywords, :meta_title, :meta_description, :show_on_intranet]]
+      end
+    end
   end
 end

--- a/app/controllers/spree/admin/pages_controller.rb
+++ b/app/controllers/spree/admin/pages_controller.rb
@@ -17,7 +17,7 @@ module Spree
   end
 
       def permitted_params
-        [:translations_attributes => [:id, :title, :body, :slug, :layout, :foreign_link, :meta_keywords, :meta_title, :meta_description, :show_on_intranet]]
+        [:translations_attributes => [:id, :title, :body, :slug, :layout, :foreign_link, :meta_keywords, :meta_title, :meta_description]]
       end
     end
   end

--- a/app/models/spree/page.rb
+++ b/app/models/spree/page.rb
@@ -13,6 +13,7 @@ class Spree::Page < ActiveRecord::Base
   scope :header_links, -> { where(show_in_header: true).visible }
   scope :footer_links, -> { where(show_in_footer: true).visible }
   scope :sidebar_links, -> { where(show_in_sidebar: true).visible }
+  scope :intranet_links, -> { where(show_on_intranet: true).visible }
 
   scope :by_store, ->(store) { joins(:stores).where('spree_pages_stores.store_id = ?', store) }
 

--- a/app/views/spree/admin/intranet/index.html.erb
+++ b/app/views/spree/admin/intranet/index.html.erb
@@ -1,0 +1,9 @@
+<h1>Intranet</h1>
+
+<ul>
+    <% @collection.where(show_on_intranet: true).each do |page| %>
+        <li>
+            <a href="<%= spree.admin_intranet_url(page) %>"><%= page.title %>
+        </li>
+    <% end %>
+</ul>  

--- a/app/views/spree/admin/intranet/index.html.erb
+++ b/app/views/spree/admin/intranet/index.html.erb
@@ -1,9 +1,9 @@
 <h1>Intranet</h1>
 
 <ul>
-    <% @collection.where(show_on_intranet: true).each do |page| %>
+    <% @collection.intranet_links.each do |page| %>
         <li>
-            <a href="<%= spree.admin_intranet_url(page) %>"><%= page.title %>
+            <%= link_to page.title, spree.admin_intranet_url(page) %>    
         </li>
     <% end %>
 </ul>  

--- a/app/views/spree/admin/intranet/show.html.erb
+++ b/app/views/spree/admin/intranet/show.html.erb
@@ -1,0 +1,1 @@
+<%= raw @object.body %>

--- a/app/views/spree/admin/pages/_form.html.erb
+++ b/app/views/spree/admin/pages/_form.html.erb
@@ -41,6 +41,13 @@
       </div>
 
       <div class="checkbox">
+        <%= f.label :show_on_intranet do %>
+          <%= f.check_box :show_on_intranet %>
+          <%= Spree::Page.human_attribute_name(:show_on_intranet) %>
+        <% end %>
+      </div>
+
+      <div class="checkbox">
         <%= f.label :show_in_sidebar do %>
           <%= f.check_box :show_in_sidebar %>
           <%= Spree::Page.human_attribute_name(:show_in_sidebar) %>

--- a/app/views/spree/admin/shared/_pages_sidebar_menu.html.erb
+++ b/app/views/spree/admin/shared/_pages_sidebar_menu.html.erb
@@ -1,5 +1,6 @@
 <% if can? :admin, Spree::Page %>
   <ul class="nav nav-sidebar">
-    <%= tab Spree::Page, url: spree.admin_pages_url, icon: 'leaf', label: plural_resource_name(Spree::Page) %>
+    <%= tab Spree::Page, url: spree.admin_pages_url, icon: 'leaf' , label: plural_resource_name(Spree::Page) %>
+    <%= tab "Intranet" , url: spree.admin_intranet_index_url, icon: 'lock' , label: "Intranet" %>
   </ul>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,9 @@ Spree::Core::Engine.add_routes do
     resources :pages do
       patch :translate, on: :member
     end
+    resources :intranet, only: [:index, :show]
   end
+
   constraints(Spree::StaticPage) do
     get '/(*path)', to: 'static_content#show', as: 'static'
   end

--- a/db/migrate/20240320000001_add_show_on_intranet_to_spree_pages.rb
+++ b/db/migrate/20240320000001_add_show_on_intranet_to_spree_pages.rb
@@ -1,0 +1,9 @@
+class AddShowOnIntranetToSpreePages < SpreeExtension::Migration[4.2]
+  def self.up
+    add_column :spree_pages, :show_on_intranet, :boolean, default: false, null: false
+  end
+
+  def self.down
+    remove_column :spree_pages, :show_on_intranet
+  end
+end


### PR DESCRIPTION
## What?
 - extend [spree_static_content plugin](https://github.com/raulpopadineti/spree_static_content) to have an extra "Intranet" checkbox that'll render the static page on a /intranet route scope
 - add new DB migration in plugin for the new :show_on_intranet column
 - add new Show on Intranet checkbox in admin when creating a new static page
 - make sure the admin controller persists the new :show_on_intranet boolean value
 - add new :intranet_links scope to the Spree::Page model that'll render only intranet pages
 - ensure intranet pages aren't rendered by default on the Spree store
 - add new route that will render intranet pages only to logged in users that have the role Admin set

## Why?
 - Needed to ease a way to upload procedures for internal hires on BWInstal.ro